### PR TITLE
Add `split_in_two` function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Added new `split_in_two` function.
+
 ## v1.0.0 - 2025-03-31
 
 - Initial release.

--- a/src/splitter.gleam
+++ b/src/splitter.gleam
@@ -38,7 +38,7 @@ pub fn new(substrings: List(String)) -> Splitter {
 /// let line_ends = splitter.new(["\n", "\r\n"])
 ///
 /// splitter.split(line_ends, "1. Bread\n2. Milk\n")
-/// // -> #("1. Bread", "\n", "2. Milk")
+/// // -> #("1. Bread", "\n", "2. Milk\n")
 ///
 /// splitter.split(line_ends, "No end of line here!")
 /// // -> #("No end of line here!", "", "")
@@ -48,6 +48,38 @@ pub fn new(substrings: List(String)) -> Splitter {
 @external(javascript, "./splitter_ffi.mjs", "split")
 pub fn split(splitter: Splitter, string: String) -> #(String, String, String)
 
+/// Use the splitter to find the first substring in the input string, splitting
+/// the input string at that point.
+///
+/// A tuple of two strings is returned:
+/// 1. The string prefix before the split.
+/// 3. The string suffix after and including the split.
+///
+/// If no substring was found then the suffix will be empty, and the prefix
+/// will be the whole input string.
+///
+/// # Examples
+///
+/// ```gleam
+/// let line_ends = splitter.new(["\n", "\r\n"])
+///
+/// splitter.split(line_ends, "1. Bread\n2. Milk\n")
+/// // -> #("1. Bread", "\n2. Milk\n")
+///
+/// splitter.split(line_ends, "No end of line here!")
+/// // -> #("No end of line here!", "")
+/// ```
+///
+@external(erlang, "splitter_ffi", "split_in_two")
+@external(javascript, "./splitter_ffi.mjs", "split_in_two")
+pub fn split_in_two(splitter: Splitter, string: String) -> #(String, String)
+
 @external(erlang, "splitter_ffi", "new")
 @external(javascript, "./splitter_ffi.mjs", "make")
 fn make(patterns: List(String)) -> Splitter
+
+pub fn main() {
+  let splitter = new(["\n", "\r\n"])
+
+  echo split_in_two(splitter, "1. Bread\n2. Milk\n")
+}

--- a/src/splitter.gleam
+++ b/src/splitter.gleam
@@ -77,9 +77,3 @@ pub fn split_in_two(splitter: Splitter, string: String) -> #(String, String)
 @external(erlang, "splitter_ffi", "new")
 @external(javascript, "./splitter_ffi.mjs", "make")
 fn make(patterns: List(String)) -> Splitter
-
-pub fn main() {
-  let splitter = new(["\n", "\r\n"])
-
-  echo split_in_two(splitter, "1. Bread\n2. Milk\n")
-}

--- a/src/splitter_ffi.erl
+++ b/src/splitter_ffi.erl
@@ -21,7 +21,7 @@ split_in_two(empty_splitter, String) ->
     {<<>>, String};
 split_in_two(Splitter, String) ->
     case binary:match(String, Splitter) of
-        nomatch -> {String, <<"">>, <<"">>};  % No delimiter found
+        nomatch -> {String, <<"">>};  % No delimiter found
         {Index, _Length} ->
             {binary:part(String, 0, Index),
              binary:part(String, Index, byte_size(String) - Index)}

--- a/src/splitter_ffi.erl
+++ b/src/splitter_ffi.erl
@@ -1,5 +1,5 @@
 -module(splitter_ffi).
--export([new/1, split/2]).
+-export([new/1, split/2, split_in_two/2]).
 
 new([]) ->
     empty_splitter;
@@ -12,7 +12,17 @@ split(Splitter, String) ->
     case binary:match(String, Splitter) of
         nomatch -> {String, <<"">>, <<"">>};  % No delimiter found
         {Index, Length} ->
-            {binary:part(String, 0, Index), 
-             binary:part(String, Index, Length), 
+            {binary:part(String, 0, Index),
+             binary:part(String, Index, Length),
              binary:part(String, Index + Length, byte_size(String) - Index - Length)}
+    end.
+
+split_in_two(empty_splitter, String) ->
+    {<<>>, String};
+split_in_two(Splitter, String) ->
+    case binary:match(String, Splitter) of
+        nomatch -> {String, <<"">>, <<"">>};  % No delimiter found
+        {Index, _Length} ->
+            {binary:part(String, 0, Index),
+             binary:part(String, Index, byte_size(String) - Index)}
     end.

--- a/src/splitter_ffi.mjs
+++ b/src/splitter_ffi.mjs
@@ -24,6 +24,16 @@ export function split(splitter, string) {
   ];
 }
 
+export function split_in_two(splitter, string) {
+  const match = string.match(splitter);
+
+  if (!match) return [string, ""]; // No delimiter found
+
+  const index = match.index;
+
+  return [string.slice(0, index), string.slice(index)];
+}
+
 function escapeRegExp(string) {
   return string.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }

--- a/test/splitter_test.gleam
+++ b/test/splitter_test.gleam
@@ -57,3 +57,55 @@ pub fn split_7_test() {
   |> splitter.split("22ab11")
   |> should.equal(#("22", "ab", "11"))
 }
+
+pub fn split_in_two_0_test() {
+  splitter.new(["a", "b"])
+  |> splitter.split_in_two("111a222")
+  |> should.equal(#("111", "a222"))
+}
+
+pub fn split_in_two_1_test() {
+  splitter.new(["a", "b"])
+  |> splitter.split_in_two("111b222")
+  |> should.equal(#("111", "b222"))
+}
+
+pub fn split_in_two_2_test() {
+  splitter.new(["a", "b"])
+  |> splitter.split_in_two("111a222b333")
+  |> should.equal(#("111", "a222b333"))
+}
+
+pub fn split_in_two_3_test() {
+  splitter.new(["a", "b"])
+  |> splitter.split_in_two("111a222b333")
+  |> should.equal(#("111", "a222b333"))
+}
+
+// Right at the start
+pub fn split_in_two_4_test() {
+  splitter.new(["a", "b"])
+  |> splitter.split_in_two("a222b333")
+  |> should.equal(#("", "a222b333"))
+}
+
+// One pattern is a substring of the other
+pub fn split_in_two_5_test() {
+  splitter.new(["ab", "a"])
+  |> splitter.split_in_two("ab11")
+  |> should.equal(#("", "ab11"))
+}
+
+// No patterns
+pub fn split_in_two_6_test() {
+  splitter.new([])
+  |> splitter.split_in_two("ab11")
+  |> should.equal(#("", "ab11"))
+}
+
+// Empty patterns
+pub fn split_in_two_7_test() {
+  splitter.new(["", "ab", "", "a", ""])
+  |> splitter.split_in_two("22ab11")
+  |> should.equal(#("22", "ab11"))
+}


### PR DESCRIPTION
Whilst attempting to migrate `glexer` to use `splitter`, I noticed that I need the separator to be included in the suffix. Doing a string concat obviously defeats the whole purpose so I've made a new `split_in_two` utility.