### PR TITLE
Resolves lpil/splitter#3

### DIFF
--- a/src/splitter.gleam
+++ b/src/splitter.gleam
@@ -100,6 +100,28 @@ pub fn split_before(splitter: Splitter, string: String) -> #(String, String)
 @external(javascript, "./splitter_ffi.mjs", "split_after")
 pub fn split_after(splitter: Splitter, string: String) -> #(String, String)
 
+/// Use the splitter to check whether any of the substrings are contained
+/// in the input string, without splitting the input string.
+///
+/// Returns a boolean value indicating whether a match was found in the input
+/// string.
+///
+/// # Examples
+///
+/// ```gleam
+/// let line_ends = splitter.new(["\n", "\r\n"])
+///
+/// splitter.would_split(line_ends, "1. Bread\n2. Milk\n")
+/// // -> True
+///
+/// splitter.would_split(line_ends, "No end of line here!")
+/// // -> False
+/// ```
+/// 
+@external(erlang, "splitter_ffi", "would_split")
+@external(javascript, "./splitter_ffi.mjs", "would_split")
+pub fn would_split(splitter: Splitter, string: String) -> Bool
+
 @external(erlang, "splitter_ffi", "new")
 @external(javascript, "./splitter_ffi.mjs", "make")
 fn make(patterns: List(String)) -> Splitter

--- a/src/splitter_ffi.erl
+++ b/src/splitter_ffi.erl
@@ -1,5 +1,5 @@
 -module(splitter_ffi).
--export([new/1, split/2, split_before/2, split_after/2]).
+-export([new/1, split/2, split_before/2, split_after/2, would_split/2]).
 
 new([]) ->
     empty_splitter;
@@ -37,3 +37,8 @@ split_after(Splitter, String) ->
             {binary:part(String, 0, SplitPoint),
              binary:part(String, SplitPoint, byte_size(String) - SplitPoint)}
     end.
+
+would_split(empty_splitter, _String) ->
+    false;
+would_split(Splitter, String) ->
+    binary:match(String, Splitter) =/= nomatch.

--- a/src/splitter_ffi.mjs
+++ b/src/splitter_ffi.mjs
@@ -42,6 +42,11 @@ export function split_after(splitter, string) {
   return [string.slice(0, split_point), string.slice(split_point)];
 }
 
+export function would_split(splitter, string) {
+  if (splitter.source === "(?:)") return false
+  return splitter.test(string)
+}
+
 function escapeRegExp(string) {
   return string.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }

--- a/test/splitter_test.gleam
+++ b/test/splitter_test.gleam
@@ -161,3 +161,65 @@ pub fn split_after_7_test() {
   |> splitter.split_after("22ab11")
   |> should.equal(#("22ab", "11"))
 }
+
+pub fn would_split_0_test() {
+  splitter.new(["a", "b"])
+  |> splitter.would_split("111a222")
+  |> should.equal(True)
+}
+
+pub fn would_split_1_test() {
+  splitter.new(["a", "b"])
+  |> splitter.would_split("111b222")
+  |> should.equal(True)
+}
+
+pub fn would_split_2_test() {
+  splitter.new(["a", "b"])
+  |> splitter.would_split("111a222b333")
+  |> should.equal(True)
+}
+
+pub fn would_split_3_test() {
+  splitter.new(["a", "b"])
+  |> splitter.would_split("111a222b333")
+  |> should.equal(True)
+}
+
+pub fn would_split_4_test() {
+  splitter.new(["a", "b"])
+  |> splitter.would_split("a222b333")
+  |> should.equal(True)
+}
+
+pub fn would_split_5_test() {
+  splitter.new(["ab", "a"])
+  |> splitter.would_split("ab11")
+  |> should.equal(True)
+}
+
+pub fn would_split_6_test() {
+  splitter.new([])
+  |> splitter.would_split("ab11")
+  |> should.equal(False)
+}
+
+pub fn would_split_7_test() {
+  splitter.new(["", "ab", "", "a", ""])
+  |> splitter.would_split("22ab11")
+  |> should.equal(True)
+}
+
+// no matching patterns
+pub fn would_split_8_test() {
+  splitter.new(["c", "3"])
+  |> splitter.would_split("11ab22ba")
+  |> should.equal(False)
+}
+
+// right at the end
+pub fn would_split_9_test() {
+  splitter.new(["b"])
+  |> splitter.would_split("11aa21ab")
+  |> should.equal(True)
+}


### PR DESCRIPTION
I've added the `would_split` functionality described in #3. All the tests pass on both runtimes and all JS targets. Let me know if there's any changes you'd like!

Note on the JS FFI: [EscapeRegExpPattern](https://tc39.es/ecma262/#sec-escaperegexppatternl) in the ECMAScript spec says that `Regexp.prototype.source` must return `(?:)` as the escaped regex if the original source is the empty string.